### PR TITLE
Change the default news.yml

### DIFF
--- a/app/helpers/forums/topics_helper.rb
+++ b/app/helpers/forums/topics_helper.rb
@@ -1,5 +1,12 @@
 module Forums
   module TopicsHelper
     include Forums::Permissions
+
+    ISOLATE_CONFIRM_MESSAGE = "Are you sure you want to unisolate this Topic?\n"\
+                              'This means any admin will be able to manage this Topic.'.freeze
+
+    UNISOLATE_CONFIRM_MESSAGE = "Are you sure you want to isolate this Topic?\n"\
+                                'This means only you and anyone you give access '\
+                                'to will be able to manage this Topic.'.freeze
   end
 end

--- a/app/services/forums/topics/isolation_service.rb
+++ b/app/services/forums/topics/isolation_service.rb
@@ -1,0 +1,17 @@
+module Forums
+  module Topics
+    module IsolationService
+      include BaseService
+
+      def call(user, topic)
+        topic.transaction do
+          topic.update(isolated: true) || rollback!
+
+          user.grant(:manage, topic) || rollback!
+
+          topic
+        end
+      end
+    end
+  end
+end

--- a/app/views/forums/topics/_form.html.haml
+++ b/app/views/forums/topics/_form.html.haml
@@ -2,5 +2,4 @@
 = f.check_box :locked
 = f.check_box :pinned
 = f.check_box :hidden
-= f.check_box :isolated
 = f.check_box :default_hidden

--- a/app/views/forums/topics/edit.html.haml
+++ b/app/views/forums/topics/edit.html.haml
@@ -13,6 +13,15 @@
 .panel.panel-danger
   .panel-heading Danger Zone
   .panel-body
+    - if @topic.isolated?
+      = button_to unisolate_forums_topic_path(@topic), method: :patch, class: 'btn btn-warning',
+                  data: { confirm: Forums::TopicsHelper::ISOLATE_CONFIRM_MESSAGE } do
+        Un-Isolate
+    - else
+      = button_to isolate_forums_topic_path(@topic), method: :patch, class: 'btn btn-warning',
+                  data: { confirm: Forums::TopicsHelper::UNISOLATE_CONFIRM_MESSAGE } do
+        Isolate
+
     = button_to forums_topic_path(@topic), method: :delete, class: 'btn btn-danger',
                 data: { confirm: 'Are you sure you want to delete this Topic?' } do
       %span.glyphicon.glyphicon-trash

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -128,6 +128,8 @@ Rails.application.routes.draw do
   namespace :forums, shallow: true do
     resources :topics, except: :index do
       concerns :subscribable
+      patch :isolate, on: :member
+      patch :unisolate, on: :member
     end
 
     resources :threads, except: :index do


### PR DESCRIPTION
Set the default `type` to `none` in order to avoid an error when the topic to take news from doesn't exist. 