### PR TITLE
Enhance team serializer to include captains

### DIFF
--- a/app/serializers/api/v1/team_serializer.rb
+++ b/app/serializers/api/v1/team_serializer.rb
@@ -8,7 +8,25 @@ module API
       attribute(:avatar_thumb_url) { object.avatar.thumb.url }
       attribute(:avatar_icon_url) { object.avatar.icon.url }
 
-      has_many :users, key: :players, serializer: UserSerializer
+      # has_many :users, key: :players, serializer: UserSerializer
+      attribute :players do
+        object.users.map do |user|
+          {
+            id: user.id,
+            name: user.name,
+            description: user.description,
+            created_at: user.created_at,
+            steam_32: user.steam_32,
+            steam_64: user.steam_64,
+            steam_id3: user.steam_id3,
+            steam_64_str: user.steam_64.to_s,
+            profile_url: user.avatar.thumb.url,
+            captain: user.can?(:edit, object)
+          }
+        end
+      end
+
+
       has_many :rosters, serializer: V1::Leagues::RosterSerializer
     end
   end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -8,8 +8,20 @@ module API
       attribute(:steam_64_str) { object.steam_64.to_s } # For dumb json implementations
       attribute(:profile_url) { object.avatar.thumb.url }
 
+      attribute :captain, if: :team_context? do
+        can_edit_team?(instance_options[:team])
+      end
+
       has_many :teams, serializer: API::V1::TeamSerializer
       has_many :rosters, serializer: API::V1::Leagues::RosterSerializer
+
+      def team_context?
+        instance_options[:team].present?
+      end
+
+      def can_edit_team?(team)
+        object.can?(:edit, team) && object.can?(:use, :teams)
+      end
     end
   end
 end


### PR DESCRIPTION
This code change is, _functional_ at least at small scale testing (citadel instance with 1 team, 1 user, 1 captain, no non captains, etc).

Simply add a "captain" attribute to all users when requesting a team from the API.

Up side: It works. Kinda.

Down side:...

- We do not use the UserSerializer in constructing the Players for a team.
- This also means that when requesting a user, as it will then get that user's teams, you will get info about all the users that team has.
- As this is largely unacceptable, I've marked this as requiring a review by /dev/zero. I unfortunately lack the experience with ruby required to achieve what i want without this side effect

I can already see how this could be used to decimate any running copy of citadel by creating dozens of teams with the same set of users, to create exponentially more operations on the server.