### PR TITLE
Add timestamps for pick-bans

### DIFF
--- a/app/presenters/league/match/pick_ban_presenter.rb
+++ b/app/presenters/league/match/pick_ban_presenter.rb
@@ -15,7 +15,7 @@ class League
         @picked_by ||= present(pick_ban.picked_by)
       end
 
-      def picked_at
+      def updated_at
         pick_ban.updated_at.strftime('%c')
       end
 

--- a/app/presenters/league/match/pick_ban_presenter.rb
+++ b/app/presenters/league/match/pick_ban_presenter.rb
@@ -15,6 +15,10 @@ class League
         @picked_by ||= present(pick_ban.picked_by)
       end
 
+      def picked_at
+        pick_ban.updated_at.strftime('%c')
+      end
+
       def map
         @map ||= present(pick_ban.map)
       end

--- a/app/views/leagues/matches/_match_pick_bans_form.html.haml
+++ b/app/views/leagues/matches/_match_pick_bans_form.html.haml
@@ -5,7 +5,7 @@
   %li.list-group-item
     = present(pick_ban).status
     .pull-right
-      = present(pick_ban).picked_at
+      = present(pick_ban).updated_at
 
 - unless next_pick_bans.empty?
 

--- a/app/views/leagues/matches/_match_pick_bans_form.html.haml
+++ b/app/views/leagues/matches/_match_pick_bans_form.html.haml
@@ -2,7 +2,10 @@
 - next_pick_bans = pick_bans.select(&:pending?)
 
 - past_pick_bans.each do |pick_ban|
-  %li.list-group-item= present(pick_ban).status
+  %li.list-group-item
+    = present(pick_ban).status
+    .pull-right
+      = present(pick_ban).picked_at
 
 - unless next_pick_bans.empty?
 


### PR DESCRIPTION
Add timestamps for pick-bans, as suggested by @coreobs in #562. This uses the `updated_at` field of the `league_match_pick_bans` table.