### PR TITLE
feat(docker): add Docker support with Dockerfile and docker-compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+node_modules/
+coverage/
+config/master.key
+config/credentials.yml.enc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM ruby:3.1.7-slim
+
+ENV RAILS_ENV=production \
+    RAILS_LOG_TO_STDOUT=1 \
+    RAILS_LOG_LEVEL=info \
+    BUNDLE_PATH=/usr/local/bundle \
+    RAILS_SERVE_STATIC_FILES=true
+
+RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    postgresql-client \
+    imagemagick \
+    libmagick++-dev \
+    libyaml-dev \
+    curl \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get update && apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN gem install bundler
+
+WORKDIR /citadel
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install --jobs 4 --retry 3 --without development test
+
+COPY . .
+
+RUN SECRET_KEY_BASE=dummy-key-for-precompilation \
+    bundle exec rake assets:precompile
+
+EXPOSE 3000
+
+ENTRYPOINT ["/citadel/docker-entrypoint.sh"]

--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,10 @@ gem 'tournament-system', '~> 2.0'
 # Backwards compatibility with ruby 2
 gem 'scanf'
 
+group :production do
+  gem 'puma', '~> 6.0'
+end
+
 group :test do
   # Use rspec for tests
   gem 'rspec-rails', '~> 6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -358,6 +358,8 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
+    puma (6.4.3)
+      nio4r (~> 2.0)
     racc (1.8.1)
     rack (2.2.13)
     rack-openid (1.4.2)
@@ -588,6 +590,7 @@ DEPENDENCIES
   pagedown-bootstrap-rails
   parallel_tests
   pg (~> 1.0)
+  puma (~> 6.0)
   rails (~> 7.1.0)
   rails-controller-testing
   rails_best_practices

--- a/README.md
+++ b/README.md
@@ -28,6 +28,28 @@ You will also need for testing:
 To configure secrets (ie. steam API key) for development, run `rails
 credentials:edit`.
 
+## Docker
+
+To run Citadel with Docker Compose:
+
+```bash
+docker compose up
+```
+
+This will start the Rails application on `http://localhost:3000`. PostgreSQL runs in a separate container and is only accessible within the Docker network for security reasons—the web container communicates with it through the internal Docker network.
+
+### Production Image
+
+The production Docker image uses Puma as the application server. Puma's behavior and logging can be controlled through environment variables:
+
+* `RAILS_MAX_THREADS` - The minimum and maximum number of threads in the thread pool (default: 5)
+* `WEB_CONCURRENCY` - The number of Puma worker processes to fork in clustered mode (default: 2)
+* `RAILS_LOG_LEVEL` - The log level for Rails logging (default: info). Valid values are: `debug`, `info`, `warn`, `error`, `fatal`
+
+By default, the application is only accessible on localhost (127.0.0.1). To expose the application to external network interfaces, remove the `127.0.0.1` binding from the port configuration in `docker-compose.yml`.
+
+If you're running Citadel in HTTP mode behind a reverse proxy that handles TLS, set `config.force_ssl = false` in `config/environments/production.rb`.
+
 ## Installing
 
 Here are some specific install instructions for operating systems/distributions.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,7 +51,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL") { :debug }.to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -21,7 +21,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
@@ -30,7 +30,7 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # you need to make sure to reconnect any threads in the `on_worker_boot`
 # block.
 #
-# preload_app!
+preload_app!
 
 # The code in the `on_worker_boot` will be called if you are using
 # clustered mode by specifying a number of `workers`. After each worker
@@ -39,9 +39,9 @@ environment ENV.fetch("RAILS_ENV") { "development" }
 # or connections that may have been created at application boot, Ruby
 # cannot share connections between processes.
 #
-# on_worker_boot do
-#   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
-# end
+on_worker_boot do
+  ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
+end
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+
+services:
+  web:
+    build: .
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      DATABASE_URL: postgresql://citadel:citadel@postgres:5432/citadel
+      RAILS_ENV: production
+      RAILS_LOG_TO_STDOUT: "true"
+    volumes:
+      - ./config/environments/production.rb:/citadel/config/environments/production.rb:ro
+      - ./config/credentials.yml.enc:/citadel/config/credentials.yml.enc:ro
+      - ./config/master.key:/citadel/config/master.key:ro
+      - ./public/uploads:/citadel/public/uploads
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: citadel
+      POSTGRES_PASSWORD: citadel
+      POSTGRES_DB: citadel
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U citadel"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+echo "Preparing database..."
+bundle exec rails db:prepare
+
+echo "Starting Puma server..."
+exec bundle exec puma -b tcp://0.0.0.0:3000


### PR DESCRIPTION
This PR adds a Dockerfile so we can easily run Citadel without having to rely on knowing about all of the requirements and build process.

I run Citadel for Brasil Fortress, and on my servers I am running everything with docker, so I wanted to contribute this back to the open-source project, so others could benefit.

PS: I am not a Ruby on Rails developer, so any feedback is welcome.

The ultimate goal is that anyone with docker installed on their computer, could just clone this repository and run `docker compose up -d` and have Citadel running without requiring a lot more knowledge.


Some things we can do in future PRs:

- A workflow to actually publish the docker image, so people can run Citadel without even having to clone the repository


